### PR TITLE
サンプルデータ変更防止機能を実装/#137

### DIFF
--- a/src/app/Consts/GraphIdConst.php
+++ b/src/app/Consts/GraphIdConst.php
@@ -4,7 +4,7 @@ namespace App\Consts;
 
 class GraphIdConst
 {
-    public const SAMPLES = [55, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    public const SAMPLES = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                                     21, 22, 23, 24, 25, 66, 67, 68, 69, 70,
                                     71, 72, 73, 74, 75, 76, 77];
 }

--- a/src/app/Consts/GraphIdConst.php
+++ b/src/app/Consts/GraphIdConst.php
@@ -4,7 +4,7 @@ namespace App\Consts;
 
 class GraphIdConst
 {
-    public const SAMPLES = [55,10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    public const SAMPLES = [55, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
                                     21, 22, 23, 24, 25, 66, 67, 68, 69, 70,
                                     71, 72, 73, 74, 75, 76, 77];
 }

--- a/src/app/Consts/GraphIdConst.php
+++ b/src/app/Consts/GraphIdConst.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Consts;
+
+class GraphIdConst
+{
+    public const SAMPLES = [55,10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                    21, 22, 23, 24, 25, 66, 67, 68, 69, 70,
+                                    71, 72, 73, 74, 75, 76, 77];
+}

--- a/src/app/Http/Controllers/Graph/GraphController.php
+++ b/src/app/Http/Controllers/Graph/GraphController.php
@@ -142,6 +142,14 @@ class GraphController extends Controller
      */
     public function update(GraphRequest $request, Graph $graph)
     {
+        foreach (\GraphIdConst::SAMPLES as $sample_graph_id) {
+            if ($sample_graph_id === $graph->id) {
+                return redirect()->route('graph.index')
+                    ->with('user_error_message',
+                        'このサンプルグラフは変更することができません。変更機能を試す場合は、新しくグラフを登録してください。');
+            }
+        }
+
         $graph->title = $request->input('title');
         $graph->memo = $request->input('memo');
         $graph->save();
@@ -171,7 +179,7 @@ class GraphController extends Controller
             $graph->tags()->attach($tag);
         });
 
-        return redirect()->route('graph.index', [$graph->id])
+        return redirect()->route('graph.index')
         ->with('status', 'グラフデータを変更しました。');
     }
 

--- a/src/app/Http/Controllers/Graph/TrashController.php
+++ b/src/app/Http/Controllers/Graph/TrashController.php
@@ -63,8 +63,19 @@ class TrashController extends Controller
      * @return \Illuminate\Http\Response
      */
 
-    public function destroy($id)
+    public function destroy(int $id)
     {
+
+        foreach (\GraphIdConst::SAMPLES as $sample_graph_id) {
+            if ($sample_graph_id === $id) {
+                return redirect()->route('trash.index')
+                ->with(
+                    'user_error_message',
+                    'このサンプルグラフは削除することができません。削除機能を試す場合は、新しくグラフを登録してください。'
+                );
+            }
+        }
+
         $graph = Graph::onlyTrashed()
             ->findOrFail($id);
 

--- a/src/config/app.php
+++ b/src/config/app.php
@@ -228,6 +228,7 @@ return [
         'PerPageConst' => App\Consts\PerPageConst::class,
         'FavoriteFlagConst' => App\Consts\FavoriteFlagConst::class,
         'UserIdConst' => App\Consts\UserIdConst::class,
+        'GraphIdConst' => App\Consts\GraphIdConst::class,
     ],
 
 ];

--- a/src/resources/js/components/users/UserFailureNotification.vue
+++ b/src/resources/js/components/users/UserFailureNotification.vue
@@ -20,7 +20,7 @@ export default {
         const options = {
             theme: "bubble",
             position: "top-center",
-            duration : 8000,
+            duration : 10000,
             fitToScreen : true,
             action: {
                 text : 'x',

--- a/src/resources/js/components/users/UserFailureNotification.vue
+++ b/src/resources/js/components/users/UserFailureNotification.vue
@@ -20,7 +20,7 @@ export default {
         const options = {
             theme: "bubble",
             position: "top-center",
-            duration : 3000,
+            duration : 8000,
             fitToScreen : true,
             action: {
                 text : 'x',

--- a/src/resources/views/components/graphs/graph_save.blade.php
+++ b/src/resources/views/components/graphs/graph_save.blade.php
@@ -32,7 +32,7 @@
                     id="memo"
                     name="memo"
                     class="form-control @error('memo') is-invalid @enderror"
-                    rows="7"
+                    rows="4"
                     autocomplete="off"
                 >{{ old('memo', $graph->memo ?? '') }}</textarea>
 
@@ -56,6 +56,17 @@
                 </span>
             @endif
         </div>
+
+        @foreach (\GraphIdConst::SAMPLES as $sample_graph_id)
+            @isset($graph->id)
+                @if ($graph->id === $sample_graph_id)
+                    <p class="text-danger text-left">
+                        <i class="fas fa-exclamation-triangle mr-1 mt-2"></i>このサンプルデータは変更できません。
+                        <br>変更機能を試す場合は、メモを新規登録してください。
+                    </p>
+                @endif
+            @endisset
+        @endforeach
 
         <div class="text-center">
             <button type="submit" v-if="isEditOperation" class="mt-3 btn btn-custom btn-block">

--- a/src/resources/views/components/graphs/graph_save.blade.php
+++ b/src/resources/views/components/graphs/graph_save.blade.php
@@ -57,16 +57,16 @@
             @endif
         </div>
 
-        @foreach (\GraphIdConst::SAMPLES as $sample_graph_id)
-            @isset($graph->id)
-                @if ($graph->id === $sample_graph_id)
-                    <p class="text-danger text-left">
-                        <i class="fas fa-exclamation-triangle mr-1 mt-2"></i>このサンプルデータは変更できません。
-                        <br>変更機能を試す場合は、メモを新規登録してください。
-                    </p>
-                @endif
-            @endisset
-        @endforeach
+        @isset($graph->id)
+            @foreach (\GraphIdConst::SAMPLES as $sample_graph_id)
+                    @if ($graph->id === $sample_graph_id)
+                        <p class="text-danger text-left">
+                            <i class="fas fa-exclamation-triangle mr-1 mt-2"></i>このサンプルデータは変更できません。
+                            <br>変更機能を試す場合は、メモを新規登録してください。
+                        </p>
+                    @endif
+            @endforeach
+        @endisset
 
         <div class="text-center">
             <button type="submit" v-if="isEditOperation" class="mt-3 btn btn-custom btn-block">

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -39,7 +39,6 @@
             ></success-notification>
         @endif
 
-        {{-- ゲストユーザー時の退会不可のエラーメッセージ --}}
         @if (session('user_error_message'))
             <user-failure-notification
                 :notification='@json(session('user_error_message'))'

--- a/src/resources/views/sub_views/graphs/index_base.blade.php
+++ b/src/resources/views/sub_views/graphs/index_base.blade.php
@@ -55,6 +55,17 @@
                     <footer class="pb-1 pt-2 text-center"><small>更新日時：{{ $graph->updated_at->format('Y/m/d H:i') }}</small></footer>
                 @else
                     <footer class="pb-1 pt-2 text-center"><small>削除日：{{ $graph->deleted_at->format('Y/m/d') }}</small></footer>
+
+                    @isset($graph->id)
+                        @foreach (\GraphIdConst::SAMPLES as $sample_graph_id)
+                                @if ($graph->id === $sample_graph_id)
+                                    <p class="text-danger text-left">
+                                        ※このサンプルデータは完全に削除できません。
+                                        <br>削除機能を試す場合は、メモを新規登録してください。
+                                    </p>
+                                @endif
+                        @endforeach
+                    @endisset
                 @endif
             </div>
 


### PR DESCRIPTION
#137 の下記タスクを実施

## タスク

- [x] サンプルデータに該当するグラフIDを条件分岐で判定し、DB更新前にリダイレクトする。
- [x] 変更画面に機能制限があることを注意書きをする。
- [x] 変更操作された場合は、トースト通知でDBには反映されていない旨を伝える。